### PR TITLE
Cambio de nombre en metodo

### DIFF
--- a/Sources/ASNetworkingLib/NetworkDispatcher.swift
+++ b/Sources/ASNetworkingLib/NetworkDispatcher.swift
@@ -213,9 +213,9 @@ extension NetworkDispatcher: AsyncDispatcherProtocol {
 
 //MARK: - PublisherDispatcherProtocol functions
 extension NetworkDispatcher: PublisherDispatcherProtocol {
-  public func fetch(uri:String? = nil,
-                    request:RequestProtocol,
-                    baseParams: ServiceParameters?) -> AnyPublisher<Response, ASNetworkError> {
+  public func fetchPublisher(uri:String? = nil,
+                             request:RequestProtocol,
+                             baseParams: ServiceParameters? = nil) -> AnyPublisher<Response, ASNetworkError> {
     let session = URLSession.shared
     guard let urlRequest = self.getUrlRequest(for: uri, request: request, parameters: baseParams) else {
       return Fail<Response, ASNetworkError>(error: ASNetworkError.errorWithDefault(.requestFailed))

--- a/Sources/ASNetworkingLib/Protocol/DispatcherProtocol.swift
+++ b/Sources/ASNetworkingLib/Protocol/DispatcherProtocol.swift
@@ -47,7 +47,7 @@ protocol AsyncDispatcherProtocol {
 }
 
 protocol PublisherDispatcherProtocol {
-  func fetch(uri:String?,
-             request:RequestProtocol,
-             baseParams: ServiceParameters?) -> AnyPublisher<Response, ASNetworkError>
+  func fetchPublisher(uri:String?,
+                      request:RequestProtocol,
+                      baseParams: ServiceParameters?) -> AnyPublisher<Response, ASNetworkError>
 }


### PR DESCRIPTION
Se cambia el nombre en el metodo fetch a fetchPublisher  para evitar conflictos con los metodos async